### PR TITLE
Publish updated input file in a more predictable location

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -72,6 +72,7 @@ ch_synapse_files
   .reduce { a, b -> "${a} ${b}" }
   .set { ch_synapse_sed }
 
+
 // Update Synapse URIs in input file with staged locations
 process update_input {
 

--- a/main.nf
+++ b/main.nf
@@ -77,7 +77,7 @@ println(input_file.parent)
 // Update Synapse URIs in input file with staged locations
 process update_input {
 
-  publishDir "${input_file.parent}/synstage/",  mode: 'copy', overwrite: true
+  publishDir "${input_file.scheme}://${input_file.parent}/synstage/",  mode: 'copy'
   publishDir "${outdir}/${run_name}/",          mode: 'copy'
 
   input:

--- a/main.nf
+++ b/main.nf
@@ -76,22 +76,22 @@ ch_synapse_files
 // Update Synapse URIs in input file with staged locations
 process update_input {
 
-  publishDir "${outdir}/${run_name}/",      mode: 'copy'
+  publishDir "${input_file.parent}/synstage/",  mode: 'copy'
+  publishDir "${outdir}/${run_name}/",          mode: 'copy'
 
   input:
-  path input    from input_file
-  val  exprs    from ch_synapse_sed
+  path "input.txt"    from input_file
+  val  exprs          from ch_synapse_sed
 
   output:
-  path "${output}"    into ch_input_tweaked
+  path "${input_file.name}"  into ch_input_tweaked
 
   when:
   synapse_uris.size() > 0
 
   script:
-  output = "${input_file.getBaseName()}.staged.${input_file.getExtension()}"
   """
-  sed -E ${exprs} ${input} > ${output}
+  sed -E ${exprs} input.txt > ${input_file.name}
   """
 
 }

--- a/main.nf
+++ b/main.nf
@@ -72,8 +72,6 @@ ch_synapse_files
   .reduce { a, b -> "${a} ${b}" }
   .set { ch_synapse_sed }
 
-println(input_file.parent)
-
 // Update Synapse URIs in input file with staged locations
 process update_input {
 

--- a/main.nf
+++ b/main.nf
@@ -72,11 +72,12 @@ ch_synapse_files
   .reduce { a, b -> "${a} ${b}" }
   .set { ch_synapse_sed }
 
+println(input_file.parent)
 
 // Update Synapse URIs in input file with staged locations
 process update_input {
 
-  publishDir "${input_file.parent}/synstage/",  mode: 'copy'
+  publishDir "${input_file.parent}/synstage/",  mode: 'copy', overwrite: true
   publishDir "${outdir}/${run_name}/",          mode: 'copy'
 
   input:


### PR DESCRIPTION
Prior to this PR, the updated input file (_i.e._ with the staged locations instead of Synapse URIs) would be stored in a folder named after the workflow run (_e.g._ `astonishing_legentil`). This makes it harder for the user to predict where the updated input file will be. 

In this PR, I added a new publish location relative to the input file. Specifically, a folder called `synstage` is created in the parent folder, and the updated input file (with the same name) is published in this `synstage` folder. See below for an example. 

```
# Original
demo/samplesheet.csv

# Output from different runs
demo/synapse/astonishing_legentil/samplesheet.csv
demo/synapse/disturbed_swanson/samplesheet.csv
demo/synapse/nice_gautier/samplesheet.csv

# Stable output location
demo/synstage/samplesheet.csv
```