### PR TITLE
Simplify workflow by making `outdir` optional and using secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,16 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
     foobar,syn://syn28521174,syn://syn28521175,unstranded
     ```
 
-2. Prepare your Synapse configuration file to authenticate the workflow. For more details, check out the [Authentication](#authentication) section.
+2. Create a user secret called `SYNAPSE_AUTH_TOKEN` in Tower with a [personal access token](https://www.synapse.org/#!PersonalAccessTokens:). For more details, check out the [Authentication](#authentication) section.
 
-    **Example:** Uploaded to `s3://example-bucket/synapse_config.ini`
+    **Example:** If using Nextflow Tower hosted by Sage Bionetworks, create a secret [here](https://tower.sagebionetworks.org/secrets).
 
-    ```ini
-    [authentication]
-    authtoken = <personal-access-token>
-    ```
-
-3. Prepare your parameters file. For more details, check out the [Parameters](#parameters) section.
+3. Prepare your parameters file. For more details, check out the [Parameters](#parameters) section. Only the `input` parameter is required.
 
     **Example:** Stored locally as `./params.yml`
 
     ```yaml
-    input: s3://example-bucket/input.csv
-    synapse_config: s3://example-bucket/synapse_config.ini
-    outdir: s3://example-bucket/synapse/
+    input: "s3://example-bucket/input.csv"
     ```
 
 4. Launch workflow using the [Nextflow CLI](https://nextflow.io/docs/latest/cli.html#run), the [Tower CLI](https://help.tower.nf/latest/cli/), or the [Tower web UI](https://help.tower.nf/latest/launch/launchpad/).
@@ -51,36 +44,37 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
     tw launch sage-bionetworks-workflows/nf-synstage --params-file=./params.yml
     ```
 
-5. Retrieve the output file. The Synapse URIs have been replaced with their staged locations. This file can now be used as the input for other workflows.
+5. Retrieve the output file, which is stored in a `synstage/` subfolder relative to the input file. The Synapse URIs have been replaced with their staged locations. This file can now be used as the input for other workflows.
 
-    **Example:** Downloaded from `s3://example-bucket/synapse/<run-name>/input.staged.csv`
+    **Example:** Downloaded from `s3://example-bucket/synstage/input.csv`
 
     ```text
     sample,fastq_1,fastq_2,strandedness
-    foobar,s3://example-bucket/synapse/syn28521174/foobar.R1.fastq.gz,s3://example-bucket/synapse/syn28521175/foobar.R2.fastq.gz,unstranded
+    foobar,s3://example-scratch/synstage/syn28521174/foobar.R1.fastq.gz,s3://example-scratch/synstage/syn28521175/foobar.R2.fastq.gz,unstranded
     ```
 
 ## Authentication
 
 Downloading files from Synapse requires the workflow to be authenticated. The workflow currently supports two authentication methods:
 
-- **(Preferred)** Create a secret called `SYNAPSE_AUTH_TOKEN` containing a Synapse personal access token using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/). 
+- **(Preferred)** Create a secret called `SYNAPSE_AUTH_TOKEN` containing a Synapse personal access token using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/).
 - Provide a Synapse configuration file containing a personal access token (see example above) to the `synapse_config` parameter. This method is best used if Nextflow/Tower secrets aren't supported on your platform. **Important:** Make sure that your `synapse_config` file is not stored in a directory that will be indexed on or uploaded to Synapse.
 
-You can generate a personal access token using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:).
+### Personal access tokens
+
+You can generate a Synapse personal access token using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:).
 
 ## Parameters
 
 Check out the [Quickstart](#quickstart) section for example parameter values.
 
-- **`input`**: A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
+- **`input`**: (Required) A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
 
 - **`synapse_config`**: (Optional) A [Synapse configuration file](https://python-docs.synapse.org/build/html/Credentials.html#use-synapseconfig) containing authentication credentials. A minimal example is included in the [Quickstart](#quickstart) section.
 
-- **`outdir`**: An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix.
+- **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix.
 
 ## Known Limitations
 
-- The workflow only supports S3 buckets as target staging locations.
 - The only way for the workflow to download Synapse files is by listing Synapse URIs in a file. You cannot provide a list of Synapse IDs or URIs to a parameter.
 - The workflow doesn't check if newer versions exist for the files associated with the Synapse URIs. If you need to force-download a newer version, you should manually delete the staged version.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Check out the [Quickstart](#quickstart) section for example parameter values.
 
 - **`input`**: (Required) A text file containing Synapse URIs (_e.g._ `syn://syn28521174`). The text file can have any format (_e.g._ a single column of Synapse URIs, a CSV/TSV sample sheet for an nf-core workflow).
 
-- **`synapse_config`**: (Optional) A [Synapse configuration file](https://python-docs.synapse.org/build/html/Credentials.html#use-synapseconfig) containing authentication credentials. A minimal example is included in the [Quickstart](#quickstart) section.
-
 - **`outdir`**: (Optional) An output location where the Synapse files will be staged. Currently, this location must be an S3 prefix.
+
+- **`synapse_config`**: (Optional) A [Synapse configuration file](https://python-docs.synapse.org/build/html/Credentials.html#use-synapseconfig) containing authentication credentials.
 
 ## Known Limitations
 

--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,8 @@ ch_synapse_config = params.synapse_config ? Channel.value(file(params.synapse_co
 
 input_file = file(params.input, checkIfExists: true)
 
-params.outdir = "${workDir.scheme}://${workDir.parent}/synstage/"
+workdir_parent = workDir.parent.replaceAll('/$', '')
+params.outdir = "${workDir.scheme}://${workdir_parent}/synstage/"
 outdir = params.outdir.replaceAll('/$', '')
 
 

--- a/main.nf
+++ b/main.nf
@@ -15,9 +15,8 @@ ch_synapse_config = params.synapse_config ? Channel.value(file(params.synapse_co
 
 input_file = file(params.input, checkIfExists: true)
 
-params.outdir = "${workDir}/synapse/"
+params.outdir = "${workDir.scheme}://${workDir.parent}/synstage/"
 outdir = params.outdir.replaceAll('/$', '')
-println(outdir)
 
 
 // Parse Synapse URIs from input file
@@ -28,8 +27,8 @@ Channel
   .fromList(synapse_uris)
   .set { ch_synapse_ids }  // channel: [ syn://syn98765432, syn98765432 ]
 
-params.name = false
-run_name = params.name ?: workflow.runName
+params.name = workflow.runName
+run_name = params.name
 
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -56,13 +56,13 @@ process synapse_get {
   script:
   if ( params.synapse_config ) {
     """
-    synapse --configPath ${syn_config} get --manifest 'suppress' ${syn_id}
+    synapse --configPath ${syn_config} get ${syn_id}
     rm ${syn_config}
     """
   } else {
     """
     # Using SYNAPSE_AUTH_TOKEN secret from the environment
-    synapse get --manifest 'suppress' ${syn_id}
+    synapse get ${syn_id}
     """
   }
 

--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,10 @@ params.synapse_config = false  // Default
 ch_synapse_config = params.synapse_config ? Channel.value(file(params.synapse_config)) : "null"
 
 input_file = file(params.input, checkIfExists: true)
+
+params.outdir = "${workDir}/synapse/"
 outdir = params.outdir.replaceAll('/$', '')
+println(outdir)
 
 
 // Parse Synapse URIs from input file


### PR DESCRIPTION
The nicest thing about this PR is that the workflow can now be run with a single input parameter, assuming you're using secrets in Tower. The default is to store the staged files in the scratch bucket, which will automatically delete files after 6 months. 

```
input: "s3://example-project-tower-bucket/samplesheet.csv"
```

Fixes #1 and #7