### PR TITLE
Deduplicate Synapse IDs before downloading them

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,7 @@ synapse_uris = (input_file.text =~ 'syn://(syn[0-9]+)').findAll()
 
 Channel
   .fromList(synapse_uris)
+  .unique()
   .set { ch_synapse_ids }  // channel: [ syn://syn98765432, syn98765432 ]
 
 params.name = workflow.runName


### PR DESCRIPTION
I hadn't accounted for the situation where the same Synapse ID is present multiple times in an input file. Fortunately, there's a built-in channel operator that eliminates duplicates. 

Fixes #10 