### PR TITLE
[IBCDPE-428] - Adds SBG support to nf-synstage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
 
 If you are staging Seven Bridges files, there are a few differences that you will want to incorporate in your Nextflow run. 
 
-#### URIs
+When adding your URIs to your input file, Seven Bridges file URIs should have the prefix `sbg://`. 
 
-When adding your URIs to your input file, Seven Bridges file URIs should have the prefix `sbg://`. Additionally, there are two ways to get the ID of a file in Seven Bridges:
+There are two ways to get the ID of a file in Seven Bridges:
+
 1. The first way involves simply logging in to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), navigating to the file and copying the ID from the URL. For example, your URL might look like this: "https://cgc.sbgenomics.com/u/brmacdonald/invite-test/files/63b717559fd1ad5d228550a0/". From this url, you would copy the "63b717559fd1ad5d228550a0" piece and combine it with the `sbg://` prefix to have the complete URI `sbg://63b717559fd1ad5d228550a0`.
 2. The second way involves using the [SBG CLI](https://docs.sevenbridges.com/docs/files-and-metadata). To get the ID numbers that you need, run the `sb files list` command and specify the project that you are downloading files from. A list of all files in the project will be returned, and you will combine the ID number with the prefix for each file that you want to stage.
+
+`nf-synstage` can handle either or both types of URIs in one run.
 
 
 ## Authentication
@@ -82,7 +85,7 @@ You can generate a Synapse personal access token using [this dashboard](https://
 To authenticate a Seven Bridges account, you need to configure two secrets. In order to retrieve your secrets, login to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), click on the "Developer" dropdown and click on "Authentication Token". 
 
 1. Copy your Authentication Token and create a secret called `SB_AUTH_TOKEN` using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/).
-2. Copy the API endpoint and create a secret called `SB_API_ENDPOINT`.
+2. Copy the API endpoint and create a secret called `SB_API_ENDPOINT` using the same method.
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-The purpose of this Nextflow workflow is to automate the process of staging Synapse files in an accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain Synapse-specific steps for downloading data. This workflow is intended to be run first in preparation for other data processing workflows.
+The purpose of this Nextflow workflow is to automate the process of staging Synapse and Seven Bridges CGC files in an accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for downloading data. This workflow is intended to be run first in preparation for other data processing workflows.
 
 Briefly, `nf-synstage` achieves this automation as follows:
 
-1. Extract all Synapse URIs (_e.g._ `syn://syn28521174`) from a given text file
-2. Download the corresponding files from Synapse in parallel
-3. Replace the Synapse URIs in the text file with their staged locations
+1. Extract all Synapse and Seven Bridges URIs (_e.g._ `syn://syn28521174` or `sbg://63b717559fd1ad5d228550a0`) from a given text file
+2. Download the corresponding files from both platforms in parallel
+3. Replace the URIs in the text file with their staged locations
 4. Output the updated text file so it can serve as input for another workflow
 
 ## Quickstart
@@ -53,16 +53,36 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
     foobar,s3://example-scratch/synstage/syn28521174/foobar.R1.fastq.gz,s3://example-scratch/synstage/syn28521175/foobar.R2.fastq.gz,unstranded
     ```
 
+### Special Considerations for Seven Bridges CGC Files
+
+If you are staging Seven Bridges files, there are a few differences that you will want to incorporate in your Nextflow run. 
+
+#### URIs
+
+When adding your URIs to your input file, Seven Bridges file URIs should have the prefix `sbg://`. Additionally, there are two ways to get the ID of a file in Seven Bridges:
+1. The first way involves simply logging in to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), navigating to the file and copying the ID from the URL. For example, your URL might look like this: "https://cgc.sbgenomics.com/u/brmacdonald/invite-test/files/63b717559fd1ad5d228550a0/". From this url, you would copy the "63b717559fd1ad5d228550a0" piece and combine it with the `sbg://` prefix to have the complete URI `sbg://63b717559fd1ad5d228550a0`.
+2. The second way involves using the [SBG CLI](https://docs.sevenbridges.com/docs/files-and-metadata). To get the ID numbers that you need, run the `sb files list` command and specify the project that you are downloading files from. A list of all files in the project will be returned, and you will combine the ID number with the prefix for each file that you want to stage.
+
+
 ## Authentication
+
+### Synapse 
 
 Downloading files from Synapse requires the workflow to be authenticated. The workflow currently supports two authentication methods:
 
 - **(Preferred)** Create a secret called `SYNAPSE_AUTH_TOKEN` containing a Synapse personal access token using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/).
 - Provide a Synapse configuration file containing a personal access token (see example above) to the `synapse_config` parameter. This method is best used if Nextflow/Tower secrets aren't supported on your platform. **Important:** Make sure that your `synapse_config` file is not stored in a directory that will be indexed on or uploaded to Synapse.
 
-### Personal access tokens
+#### Personal access tokens
 
 You can generate a Synapse personal access token using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:).
+
+### Seven Bridges CGC
+
+To authenticate a Seven Bridges account, you need to configure two secrets. In order to retrieve your secrets, login to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), click on the "Developer" dropdown and click on "Authentication Token". 
+
+1. Copy your Authentication Token and create a secret called `SB_AUTH_TOKEN` using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/).
+2. Copy the API endpoint and create a secret called `SB_API_ENDPOINT`.
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-The purpose of this Nextflow workflow is to automate the process of staging Synapse and Seven Bridges CGC files in an accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for downloading data. This workflow is intended to be run first in preparation for other data processing workflows.
+The purpose of this Nextflow workflow is to automate the process of staging Synapse and SevenBridges files in an accessible location (_e.g._ an S3 bucket). In turn, these staged files can be used as input for a general-purpose (_e.g._ nf-core) workflow that doesn't contain platform-specific steps for downloading data. This workflow is intended to be run first in preparation for other data processing workflows.
 
 Briefly, `nf-synstage` achieves this automation as follows:
 
-1. Extract all Synapse and Seven Bridges URIs (_e.g._ `syn://syn28521174` or `sbg://63b717559fd1ad5d228550a0`) from a given text file
+1. Extract all Synapse and SevenBridges URIs (_e.g._ `syn://syn28521174` or `sbg://63b717559fd1ad5d228550a0`) from a given text file
 2. Download the corresponding files from both platforms in parallel
 3. Replace the URIs in the text file with their staged locations
 4. Output the updated text file so it can serve as input for another workflow
@@ -53,15 +53,15 @@ The examples below demonstrate how you would stage Synapse files in an S3 bucket
     foobar,s3://example-scratch/synstage/syn28521174/foobar.R1.fastq.gz,s3://example-scratch/synstage/syn28521175/foobar.R2.fastq.gz,unstranded
     ```
 
-### Special Considerations for Seven Bridges CGC Files
+### Special Considerations for SevenBridges Files
 
-If you are staging Seven Bridges files, there are a few differences that you will want to incorporate in your Nextflow run. 
+If you are staging SevenBridges files, there are a few differences that you will want to incorporate in your Nextflow run. 
 
-When adding your URIs to your input file, Seven Bridges file URIs should have the prefix `sbg://`. 
+When adding your URIs to your input file, SevenBridges file URIs should have the prefix `sbg://`. 
 
-There are two ways to get the ID of a file in Seven Bridges:
+There are two ways to get the ID of a file in SevenBridges:
 
-1. The first way involves simply logging in to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), navigating to the file and copying the ID from the URL. For example, your URL might look like this: "https://cgc.sbgenomics.com/u/brmacdonald/invite-test/files/63b717559fd1ad5d228550a0/". From this url, you would copy the "63b717559fd1ad5d228550a0" piece and combine it with the `sbg://` prefix to have the complete URI `sbg://63b717559fd1ad5d228550a0`.
+1. The first way involves logging into a SevenBridges portal, such as [SevenBridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), navigating to the file and copying the ID from the URL. For example, your URL might look like this: "https://cgc.sbgenomics.com/u/user_name/project/63b717559fd1ad5d228550a0/". From this url, you would copy the "63b717559fd1ad5d228550a0" piece and combine it with the `sbg://` prefix to have the complete URI `sbg://63b717559fd1ad5d228550a0`.
 2. The second way involves using the [SBG CLI](https://docs.sevenbridges.com/docs/files-and-metadata). To get the ID numbers that you need, run the `sb files list` command and specify the project that you are downloading files from. A list of all files in the project will be returned, and you will combine the ID number with the prefix for each file that you want to stage.
 
 `nf-synstage` can handle either or both types of URIs in one run.
@@ -80,12 +80,12 @@ Downloading files from Synapse requires the workflow to be authenticated. The wo
 
 You can generate a Synapse personal access token using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:).
 
-### Seven Bridges CGC
+### SevenBridges
 
-To authenticate a Seven Bridges account, you need to configure two secrets. In order to retrieve your secrets, login to [Seven Bridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), click on the "Developer" dropdown and click on "Authentication Token". 
+To authenticate a SevenBridges account, you need to configure two secrets. In order to retrieve your secrets, login to a SevenBridges portal, such as [SevenBridges CGC](https://cgc-accounts.sbgenomics.com/auth/login), click on the "Developer" dropdown and click on "Authentication Token". 
 
 1. Copy your Authentication Token and create a secret called `SB_AUTH_TOKEN` using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html) or [Nextflow Tower](https://help.tower.nf/latest/secrets/overview/).
-2. Copy the API endpoint and create a secret called `SB_API_ENDPOINT` using the same method.
+2. Copy the API endpoint and create a secret called `SB_API_ENDPOINT` using the same method. A full list of SevenBridges API endpoints can be found [here](https://sevenbridges-python.readthedocs.io/en/latest/quickstart/#authentication-and-configuration)
 
 ## Parameters
 

--- a/main.nf
+++ b/main.nf
@@ -109,15 +109,8 @@ process sbg_get {
   """
 
 }
-// Mix channels, allowing for either of them to be null
-if (ch_synapse_files == null) {
-    ch_all_files = ch_sbg_files
-} else if (ch_sbg_files == null) {
-  ch_all_files = ch_synapse_files
-} else {
-  ch_all_files = ch_synapse_files.mix(ch_sbg_files)
-}
-
+// Mix channels
+ch_all_files = ch_synapse_files.mix(ch_sbg_files)
 // Convert Mixed URIs and staged locations into sed expressions
 ch_all_files
   .map { uri, id, file -> /-e 's|\b${uri}\b|${outdir}\/${id}\/${file.name}|g'/ }

--- a/main.nf
+++ b/main.nf
@@ -103,7 +103,7 @@ process sbg_get {
   import sevenbridges as sbg
 
   api = sbg.Api()
-  download_file = api.files.get("63b717559fd1ad5d228550a0")
+  download_file = api.files.get('${sbg_id}')
   download_file.download(download_file.name)
 
   """


### PR DESCRIPTION
This PR adds support for Seven Bridges URIs to nf-synstage, and updates the README file with information about how to use the new feature. At present, the SBG file staging works by taking URIs with the `sbg://{id}` format. The ID for each file is then passed to `sbg_get` in a separate channel while synapse ids are handled by the existing `synapse_get` process. The two channels are then brought back together (allowing for either channel to be `null`) before the `update_input` process is run. This workflow has been tested in an ec2 instance, and in tower on an example file in my CGC account, but has not yet been tested on files within the account that James set up (because I don't have access yet I could not retrieve file IDs to test with). 