### PR TITLE
pin nextflow version to allow DSL1

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ manifest {
 	homePage = 'https://github.com/Sage-Bionetworks-Workflows/nf-synstage'
 	description = 'Nextflow pipeline for staging files from Synapse'
 	mainScript = 'main.nf'
-	nextflowVersion = '>=21.09.0-edge'
+	nextflowVersion = '>=21.09.0-edge, <22.12.0-edge'
 	version = '0.1'
 	defaultBranch = 'main'
 }


### PR DESCRIPTION
Problem:
```
N E X T F L O W  ~  version 23.04.2
Pulling Sage-Bionetworks-Workflows/nf-synstage ...
 downloaded from https://github.com/Sage-Bionetworks-Workflows/nf-synstage.git
Nextflow DSL1 is no longer supported — Update your script to DSL2, or use Nextflow 22.10.x or earlier
```

Solution:
Pin the version that nextflow can use to allow DSL1 - format is defined in the manifest: https://www.nextflow.io/docs/latest/config.html#scope-manifest
`manifest.nextflowVersion = '>=1.2, <=1.5' // any version in the 1.2 .. 1.5 range`

https://www.nextflow.io/docs/latest/dsl1.html#migrating-from-dsl-1
> In Nextflow version 22.03.0-edge, DSL2 became the default DSL version. In version 22.12.0-edge, DSL1 support was removed